### PR TITLE
Fix casing in include and fix test

### DIFF
--- a/src/modelFactory.cpp
+++ b/src/modelFactory.cpp
@@ -5,7 +5,7 @@
 
 #include "FlatZincLexer.h"
 #include "FlatZincParser.h"
-#include "FznVisitor.hpp"
+#include "fznVisitor.hpp"
 
 std::unique_ptr<fznparser::Model> fznparser::ModelFactory::create(
     const std::filesystem::path& modelFile) {

--- a/test/src/tModelFactoryTest.cpp
+++ b/test/src/tModelFactoryTest.cpp
@@ -41,7 +41,7 @@ TEST(ModelFactoryTest, parsing_of_array_variables) {
     EXPECT_EQ(arrayVar->contents()[1], variables[1]);
 
     EXPECT_EQ(arrayVar->annotations().size(), 1);
-    EXPECT_TRUE(arrayVar->annotations().has<OutputAnnotation>());
+    EXPECT_TRUE(arrayVar->annotations().has<OutputArrayAnnotation>());
 }
 
 TEST(ModelFactoryTest, parsing_of_constraints) {


### PR DESCRIPTION
Forgot to update a test, and apparently the casing in one of the include directives was incorrect.