### PR TITLE
Add ability to parse strings and other input streams

### DIFF
--- a/include/fznparser/parser.hpp
+++ b/include/fznparser/parser.hpp
@@ -10,6 +10,9 @@
 
 namespace fznparser {
 
+Model parseFznIstream(std::istream& fznStream);
 Model parseFznFile(const std::string& fznFilePath);
+Model parseFznString(const std::string& fznContent);
+Model parseFznString(std::string&& fznContent);
 
 }  // namespace fznparser


### PR DESCRIPTION
The minimal changes we talked about to allow the parsing of FlatZinc directly from a string (rather than writing them to a file first). This is used in the direct MiniZinc interface to Atlantis